### PR TITLE
feat(proxy): support forwardThinking="content" mode for OpenClaw streaming cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Sessions are persisted to disk and reused via `--resume` for faster subsequent r
 - **Interactive model selection** — `setup`/`upgrade` present all discovered models via `@clack/prompts` (single-select primary, multi-select ordered fallbacks)
 - **Dynamic model discovery** — models auto-detected from `cursor-agent --list-models`, synced to OpenClaw on every gateway start
 - **Real-time streaming** — `--stream-partial-output` for character-level text deltas; instant result by default (plugin config `instantResult`), with optional smart-chunked fallback
-- **Thinking forwarding** — optionally stream LLM reasoning via `reasoning_content` (plugin config `forwardThinking`)
+- **Thinking forwarding** — optionally stream LLM reasoning (plugin config `forwardThinking`): `"reasoning_content"` via standard field, `"content"` as markdown blockquote in message body (compatible with OpenClaw Feishu/Slack streaming cards)
 - **Rich tool descriptions** — MCP server instructions include token extraction rules, exact action keys, and parameter examples from SKILL.md — reducing unnecessary `openclaw_skill` calls
 - **Tool call logging** — proxy logs every tool invocation with name, arguments summary, duration, and call ID for diagnostics
 - **Tool auto-discovery** — disk-based registration from SKILL.md at startup (no Gateway dependency); background verification for diagnostics; cached with 60s TTL

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -136,7 +136,7 @@ flowchart TD
 - **交互式模型选择** — `setup`/`upgrade` 通过 `@clack/prompts` 展示所有发现的模型（主模型单选，备用模型按顺序多选）
 - **动态模型发现** — 自动从 `cursor-agent --list-models` 获取模型列表，每次 Gateway 启动时同步
 - **实时流式** — `--stream-partial-output` 逐字输出；批量结果默认即时发送（插件 config `instantResult`），可选智能分块回退
-- **推理过程转发** — 可选通过 `reasoning_content` 流式输出 LLM 推理过程（插件 config `forwardThinking`）
+- **推理过程转发** — 可选流式输出 LLM 推理过程（插件 config `forwardThinking`）：`"reasoning_content"` 通过标准字段转发，`"content"` 以 markdown 引用格式嵌入正文（兼容 OpenClaw 飞书/Slack 等流式卡片）
 - **丰富工具描述** — MCP 服务器指令包含 token 提取规则、精确 action 键和参数示例（来自 SKILL.md），减少不必要的 `openclaw_skill` 调用
 - **工具调用日志** — proxy 记录每个工具调用的名称、参数摘要、耗时和 call ID，便于诊断
 - **工具自动发现** — 启动时从磁盘 SKILL.md 直接注册（不依赖 Gateway）；后台异步验证用于诊断；60s TTL 缓存

--- a/mcp-server/streaming-proxy.mjs
+++ b/mcp-server/streaming-proxy.mjs
@@ -57,7 +57,12 @@ const API_KEY = process.env.CURSOR_PROXY_API_KEY || proxyConfigFile.apiKey || ""
 const OUTPUT_FORMAT = process.env.CURSOR_OUTPUT_FORMAT || proxyConfigFile.outputFormat || "stream-json";
 // Model is taken from each request (gateway-specified); no global override.
 
-const FORWARD_THINKING = fromConfig("forwardThinking", false, (v) => v === true || v === "true");
+const RAW_FORWARD_THINKING = fromConfig("forwardThinking", false, (v) => {
+  if (v === "content") return "content";
+  if (v === true || v === "true" || v === "reasoning_content") return "reasoning_content";
+  return false;
+});
+const FORWARD_THINKING = RAW_FORWARD_THINKING !== false;
 const INSTANT_RESULT = fromConfig("instantResult", true, (v) => v !== false && v !== "false");
 const TARGET_CHARS_PER_SEC = parseInt(fromConfig("streamSpeed", "200"), 10) || 200;
 const SHORT_TEXT_THRESHOLD = 100;
@@ -386,6 +391,8 @@ function processStreamOutput(child, { requestId, model, sessionKey, res, streamS
     let resultText = "";
     let hasStreamedContent = false;
     let error = null;
+    let thinkingPhase = false;
+    let thinkingEnded = false;
     const toolCalls = new Map();
 
     const done = () => {
@@ -429,21 +436,41 @@ function processStreamOutput(child, { requestId, model, sessionKey, res, streamS
       }
 
       if (type === "thinking") {
-        if (FORWARD_THINKING && parsed.text) {
-          hasStreamedContent = true;
-          if (streamState) ensureStreamHeaders(res, streamState);
-          const delta = { reasoning_content: parsed.text };
-          const chunk = {
-            id: requestId, object: "chat.completion.chunk",
-            created: Math.floor(Date.now() / 1000), model,
-            choices: [{ index: 0, delta, finish_reason: null }],
-          };
-          res.write("data: " + JSON.stringify(chunk) + "\n\n");
+        if (FORWARD_THINKING) {
+          if (parsed.subtype === "completed") {
+            thinkingEnded = true;
+            return;
+          }
+          if (parsed.text) {
+            hasStreamedContent = true;
+            if (streamState) ensureStreamHeaders(res, streamState);
+            if (RAW_FORWARD_THINKING === "content") {
+              let prefix = "";
+              if (!thinkingPhase) {
+                thinkingPhase = true;
+                prefix = "> 💭 ";
+              }
+              const text = prefix + parsed.text.replace(/\n/g, "\n> ");
+              res.write(sseEvent(requestId, model, { content: text }));
+            } else {
+              const delta = { reasoning_content: parsed.text };
+              const chunk = {
+                id: requestId, object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000), model,
+                choices: [{ index: 0, delta, finish_reason: null }],
+              };
+              res.write("data: " + JSON.stringify(chunk) + "\n\n");
+            }
+          }
         }
         return;
       }
 
       if (type === "text" && parsed.text) {
+        if (RAW_FORWARD_THINKING === "content" && thinkingEnded && thinkingPhase) {
+          thinkingPhase = false;
+          res.write(sseEvent(requestId, model, { content: "\n\n---\n\n" }));
+        }
         hasStreamedContent = true;
         if (streamState) ensureStreamHeaders(res, streamState);
         res.write(sseEvent(requestId, model, { content: parsed.text }));
@@ -773,7 +800,7 @@ async function handleNonStream(req, res, body) {
           message: {
             role: "assistant",
             content: result.resultText,
-            ...(result.thinkingText ? { reasoning_content: result.thinkingText } : {}),
+            ...(result.thinkingText && RAW_FORWARD_THINKING === "reasoning_content" ? { reasoning_content: result.thinkingText } : {}),
           },
           finish_reason: "stop",
         }],
@@ -901,7 +928,7 @@ server.listen(PORT, "127.0.0.1", () => {
   } else {
     log("warn", "cursor-agent not found — all /v1/chat/completions requests will fail. Set CURSOR_PATH or install Cursor.");
   }
-  log("info", `Model: from request (gateway), Format: ${OUTPUT_FORMAT}, Partial: on, Thinking: ${FORWARD_THINKING ? "forward" : "drop"}, InstantResult: ${INSTANT_RESULT}, SessionAuto: true`);
+  log("info", `Model: from request (gateway), Format: ${OUTPUT_FORMAT}, Partial: on, Thinking: ${RAW_FORWARD_THINKING || "drop"}, InstantResult: ${INSTANT_RESULT}, SessionAuto: true`);
   log("info", `Sessions loaded: ${sessions.size} (max ${MAX_SESSIONS})`);
   if (API_KEY) log("info", "API key authentication enabled");
   if (WORKSPACE_DIR) log("info", `Workspace: ${WORKSPACE_DIR}`);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -57,9 +57,12 @@
         "description": "Send batch results instantly. Synced to cursor-proxy.json."
       },
       "forwardThinking": {
-        "type": "boolean",
+        "oneOf": [
+          { "type": "boolean" },
+          { "type": "string", "enum": ["content", "reasoning_content"] }
+        ],
         "default": false,
-        "description": "Stream LLM reasoning as reasoning_content. Synced to cursor-proxy.json."
+        "description": "Stream LLM reasoning. false=drop, true/'reasoning_content'=as reasoning_content field, 'content'=as regular content (markdown blockquote, compatible with OpenClaw streaming cards). Synced to cursor-proxy.json."
       },
       "streamSpeed": {
         "type": "number",


### PR DESCRIPTION
## Summary

- Add `forwardThinking: "content"` mode that sends LLM thinking tokens as regular `content` (markdown blockquote `> 💭 ...`) instead of `reasoning_content`, making thinking visible in OpenClaw channel streaming cards (Feishu, Slack, etc.)
- The existing `forwardThinking: true` / `"reasoning_content"` behavior is preserved unchanged
- Update `openclaw.plugin.json` schema to accept `boolean | "content" | "reasoning_content"`

## Problem

OpenClaw gateway's streaming layer only propagates the `content` field from SSE deltas to channel streaming cards. The `reasoning_content` field is accumulated but not forwarded to `onPartialReply`. This means when `forwardThinking: true`, users see only "⏳ Thinking..." in Feishu streaming cards during the (often lengthy) reasoning phase, with no visibility into what the model is doing.

## Solution

Introduce `forwardThinking: "content"` mode:
- Thinking tokens are sent as regular `content` in SSE deltas, formatted as markdown blockquotes (`> 💭 ...`)
- When thinking completes and actual text begins, a horizontal rule (`---`) separator is inserted
- This works with OpenClaw's existing streaming infrastructure without requiring core changes

### `forwardThinking` values:

| Value | Behavior |
|-------|----------|
| `false` (default) | Drop thinking tokens |
| `true` / `"reasoning_content"` | Send as `reasoning_content` field (original) |
| `"content"` | Send as regular `content` in blockquote format (**new**) |

### Example Feishu card output:

```
> 💭 Let me analyze the user's request...
> They want to generate an image using seedream...

---

Here's the generated image! I used the seedream API with...
```

## Files changed

- `mcp-server/streaming-proxy.mjs` — core logic for content-mode thinking forwarding
- `openclaw.plugin.json` — schema update for `forwardThinking` field
- `README.md` / `README_ZH.md` — documentation update

## Backward compatibility

Fully backward compatible. Default value unchanged (`false`). Existing `true` behavior preserved.


Made with [Cursor](https://cursor.com)