### PR TITLE
fix: ship compiled runtime output for npm plugin installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ship compiled plugin runtime output (`dist/index.js`) in npm packages so `openclaw plugins install openclaw-cursor-brain` works on OpenClaw 2026.6+.
 - Resolve plugin root correctly when the runtime entry is loaded from `dist/`.
+- Prefer Cursor Agent over other `agent` binaries on PATH (e.g. Grok) when auto-detecting `cursorPath`.
 
 ## [1.5.4] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Ship compiled plugin runtime output (`dist/index.js`) in npm packages so `openclaw plugins install openclaw-cursor-brain` works on OpenClaw 2026.6+.
+- Resolve plugin root correctly when the runtime entry is loaded from `dist/`.
+
 ## [1.5.4] - 2026-03-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefer Cursor Agent over other `agent` binaries on PATH (e.g. Grok) when auto-detecting `cursorPath`.
 - Defer interactive install setup so `register()` stays synchronous for OpenClaw's compiled runtime loader.
 - Skip interactive model selection during `plugins install`; OpenClaw aborts with "config changed since last load" after register writes `openclaw.json`. Use `openclaw cursor-brain setup` instead.
+- Skip all `openclaw.json` writes during `plugins install`; provider/model sync runs on gateway restart or `cursor-brain setup`.
 
 ## [1.5.4] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve plugin root correctly when the runtime entry is loaded from `dist/`.
 - Prefer Cursor Agent over other `agent` binaries on PATH (e.g. Grok) when auto-detecting `cursorPath`.
 - Defer interactive install setup so `register()` stays synchronous for OpenClaw's compiled runtime loader.
+- Skip interactive model selection during `plugins install`; OpenClaw aborts with "config changed since last load" after register writes `openclaw.json`. Use `openclaw cursor-brain setup` instead.
 
 ## [1.5.4] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ship compiled plugin runtime output (`dist/index.js`) in npm packages so `openclaw plugins install openclaw-cursor-brain` works on OpenClaw 2026.6+.
 - Resolve plugin root correctly when the runtime entry is loaded from `dist/`.
 - Prefer Cursor Agent over other `agent` binaries on PATH (e.g. Grok) when auto-detecting `cursorPath`.
+- Defer interactive install setup so `register()` stays synchronous for OpenClaw's compiled runtime loader.
 
 ## [1.5.4] - 2026-03-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing! Here's how to get started.
 git clone https://github.com/andeya/openclaw-cursor-brain.git
 cd openclaw-cursor-brain
 npm install
+npm run build
 ```
 
 ### Local Testing

--- a/index.ts
+++ b/index.ts
@@ -853,6 +853,7 @@ const plugin = {
     const isUninstalling = isCursorBrainUninstallOrUpgrade;
     const isProxyCmd = /\bcursor-brain\s+proxy\b/.test(argv);
     const isSetupOnly = process.argv.includes("cursor-brain") && process.argv.includes("setup");
+    const isReadOnlyCliCmd = /\bcursor-brain\s+(doctor|status)\b/.test(argv);
 
     // Fix invalid source value on disk immediately so OpenClaw config validation won't overwrite
     if (!isPluginsInstall) {
@@ -960,7 +961,7 @@ const plugin = {
       const effectiveCursorPath = result.cursorPath || detectCursorPath(pluginConfig.cursorPath as string | undefined);
       const effectiveOutputFormat =
         result.outputFormat ?? (effectiveCursorPath ? detectOutputFormat(effectiveCursorPath, pluginConfig.outputFormat as string | undefined) : undefined);
-      if (effectiveCursorPath && !isProxyCmd && !isPluginsInstall && !isSetupOnly) {
+      if (effectiveCursorPath && !isProxyCmd && !isPluginsInstall && !isSetupOnly && !isReadOnlyCliCmd) {
         const proxyOpts = {
           pluginDir,
           cursorPath: effectiveCursorPath,
@@ -1091,7 +1092,7 @@ const plugin = {
             cursorPathOverride: pluginConfig.cursorPath as string | undefined,
           });
           console.log(formatDoctorResults(checks));
-          if (checks.some((c) => !c.ok)) process.exitCode = 1;
+          process.exit(checks.some((c) => !c.ok) ? 1 : 0);
         });
 
       prog

--- a/index.ts
+++ b/index.ts
@@ -875,7 +875,7 @@ const plugin = {
     const config = api.config;
     const pluginConfig = api.pluginConfig || {};
 
-    if (!isUninstalling) {
+    if (!isUninstalling && !isReadOnlyCliCmd) {
       const ctx: SetupContext = {
         pluginDir,
         gatewayPort: config.gateway?.port ?? 18789,
@@ -1141,6 +1141,7 @@ const plugin = {
           console.log(`  Gateway:          http://127.0.0.1:${config.gateway?.port ?? 18789}`);
           console.log(`  MCP config:       ${getCursorMcpConfigPath()}`);
           console.log(`  Tool candidates:  ${toolCandidates} (from plugin sources)`);
+          process.exit(0);
         });
 
       prog

--- a/index.ts
+++ b/index.ts
@@ -121,7 +121,7 @@ function computeFileHash(filePath: string): string {
   } catch { return "unknown"; }
 }
 
-/** Run interactive setup (model selection + plugin config) in the same process during install. Blocks until user completes; re-applies in setImmediate after core may overwrite. */
+/** Run interactive setup (model selection + plugin config) after register completes. */
 async function runInteractiveSetupInProcess(opts: {
   pluginDir: string;
   config: Record<string, any>;
@@ -172,6 +172,17 @@ async function runInteractiveSetupInProcess(opts: {
     gatewayRestartOutroShown = true;
     clack.outro("Run `openclaw gateway restart` (or restart your gateway) to apply changes.");
   }
+}
+
+function scheduleInteractiveSetupInProcess(
+  opts: Parameters<typeof runInteractiveSetupInProcess>[0],
+  logger: { warn: (msg: string) => void },
+) {
+  setImmediate(() => {
+    void runInteractiveSetupInProcess(opts).catch((e: any) => {
+      logger.warn(`Interactive setup failed: ${e?.message ?? String(e)}`);
+    });
+  });
 }
 
 function readPackageVersion(dir: string): string {
@@ -915,7 +926,9 @@ const plugin = {
             } catch (e: any) {
               api.logger.warn(`Could not set default model: ${e?.message ?? String(e)}`);
             }
-            if (runInteractiveSetup) return runInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort });
+            if (runInteractiveSetup) {
+              scheduleInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort }, api.logger);
+            }
           } else {
             // Read fresh config from disk rather than using api.config snapshot,
             // which may contain stale plugins data (e.g. during install subprocess
@@ -967,13 +980,19 @@ const plugin = {
                 writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(patch, null, 2) + "\n");
                 api.logger.info(`Provider "${PROVIDER_ID}" synced (${discovered.length} models, port ${proxyPort})`);
                 doSyncInstallRecord();
-                if (runInteractiveSetup) return runInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort });
-                setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
+                if (runInteractiveSetup) {
+                  scheduleInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort }, api.logger);
+                } else {
+                  setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
+                }
               } catch (err: any) {
                 api.logger.warn(`Could not write config: ${err?.message ?? String(err)}`);
                 doSyncInstallRecord();
-                if (runInteractiveSetup) return runInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort });
-                setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
+                if (runInteractiveSetup) {
+                  scheduleInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort }, api.logger);
+                } else {
+                  setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
+                }
               }
             } else {
               api.runtime.config.writeConfigFile(patch as any).then(() => {

--- a/index.ts
+++ b/index.ts
@@ -429,29 +429,101 @@ function normalizePluginInstallRecordSource(draft: Record<string, any>): void {
   if (installRecord?.source === "tarball") installRecord.source = "archive";
 }
 
+const CURSOR_LOCAL_MODEL_REF_RE = /(?:^|\/)cursor-local\/([^/]+)$/;
+
+function extractCursorLocalModelId(modelRef: string | undefined): string | undefined {
+  if (!modelRef) return undefined;
+  const normalized = String(modelRef).trim();
+  const nested = normalized.match(CURSOR_LOCAL_MODEL_REF_RE);
+  if (nested) return nested[1];
+  if (normalized.startsWith(`${PROVIDER_ID}/`)) {
+    const tail = normalized.slice(PROVIDER_ID.length + 1);
+    return tail.split("/").pop() || tail;
+  }
+  if (!normalized.includes("/")) return normalized;
+  return normalized.split("/").pop();
+}
+
+function formatCursorLocalModelRef(modelId: string): string {
+  return `${PROVIDER_ID}/${modelId}`;
+}
+
+function normalizeCursorLocalModelRef(modelRef: string | undefined, fallback = "auto"): string {
+  return formatCursorLocalModelRef(extractCursorLocalModelId(modelRef) || fallback);
+}
+
+function isValidCursorLocalModelRef(modelRef: string | undefined): boolean {
+  if (!modelRef) return false;
+  const modelId = extractCursorLocalModelId(modelRef);
+  if (!modelId) return false;
+  return modelRef === formatCursorLocalModelRef(modelId);
+}
+
+function normalizeCursorLocalFallbacks(
+  fallbacks: string[] | undefined,
+  discovered: CursorModel[],
+  primaryId: string,
+): string[] {
+  if (fallbacks?.length) {
+    const normalized = fallbacks.map((f) => normalizeCursorLocalModelRef(f));
+    return [...new Set(normalized.filter((f) => extractCursorLocalModelId(f) !== primaryId))];
+  }
+  return discovered
+    .filter((m) => m.id !== primaryId)
+    .map((m) => formatCursorLocalModelRef(m.id));
+}
+
+function cleanupStaleCursorLocalAliasProviders(draft: Record<string, any>): boolean {
+  const providers = draft.models?.providers as Record<string, any> | undefined;
+  const cursorProvider = providers?.[PROVIDER_ID];
+  if (!providers || !cursorProvider?.baseUrl) return false;
+
+  const cursorBaseUrl = cursorProvider.baseUrl;
+  let changed = false;
+  for (const [providerId, providerConfig] of Object.entries(providers)) {
+    if (providerId === PROVIDER_ID) continue;
+    const cfg = providerConfig as Record<string, any>;
+    if (cfg.baseUrl !== cursorBaseUrl) continue;
+    const models = cfg.models as Array<{ id?: string }> | undefined;
+    const looksLikeCursorAlias =
+      providerId.toLowerCase().includes("cursor") ||
+      models?.some((m) => String(m.id || "").includes(`${PROVIDER_ID}/`));
+    if (looksLikeCursorAlias) {
+      delete providers[providerId];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 function applyDefaultAgentModel(
   draft: Record<string, any>,
   discovered: CursorModel[],
   options: { providerExists: boolean },
 ): boolean {
-  const currentPrimary = (draft.agents?.defaults?.model as any)?.primary;
-  const shouldSetDefaultModel =
+  const currentPrimary = (draft.agents?.defaults?.model as any)?.primary as string | undefined;
+  const existingFallbacks = (draft.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
+  const normalizedPrimary = normalizeCursorLocalModelRef(currentPrimary, "auto");
+  const primaryId = extractCursorLocalModelId(normalizedPrimary) || "auto";
+  const normalizedFallbacks = normalizeCursorLocalFallbacks(existingFallbacks, discovered, primaryId);
+
+  const shouldFixPrimary =
     !options.providerExists ||
     !currentPrimary ||
-    String(currentPrimary).startsWith(`${PROVIDER_ID}/`);
-  if (!shouldSetDefaultModel) return false;
+    !isValidCursorLocalModelRef(currentPrimary);
+  const shouldFixFallbacks =
+    !existingFallbacks?.length ||
+    existingFallbacks.length !== normalizedFallbacks.length ||
+    existingFallbacks.some((f, i) => f !== normalizedFallbacks[i]);
 
-  const primary = (currentPrimary as string)?.replace(`${PROVIDER_ID}/`, "") || "auto";
-  const existingFallbacks = (draft.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
-  const fallbacks = existingFallbacks?.length
-    ? existingFallbacks
-    : discovered.filter((m) => m.id !== primary).map((m) => `${PROVIDER_ID}/${m.id}`);
+  if (!shouldFixPrimary && !shouldFixFallbacks) return false;
 
   const agents = draft.agents || {};
   const defaults = agents.defaults || {};
-  defaults.model = { primary: `${PROVIDER_ID}/${primary}`, fallbacks };
+  defaults.model = { primary: normalizedPrimary, fallbacks: normalizedFallbacks };
   agents.defaults = defaults;
   draft.agents = agents;
+  cleanupStaleCursorLocalAliasProviders(draft);
   return true;
 }
 
@@ -741,12 +813,15 @@ function removePluginFromOpenClawConfig(): boolean {
     const prefix = `${PROVIDER_ID}/`;
     const defaults = cfg.agents?.defaults;
     if (defaults?.model) {
-      if ((defaults.model.primary || "").toString().startsWith(prefix)) {
+      const primary = defaults.model.primary;
+      if (primary && (String(primary).startsWith(prefix) || String(primary).includes(`/${prefix}`))) {
         delete defaults.model.primary;
         changed = true;
       }
       if (defaults.model.fallbacks && Array.isArray(defaults.model.fallbacks)) {
-        const cleaned = defaults.model.fallbacks.filter((f: string) => !f.startsWith(prefix));
+        const cleaned = defaults.model.fallbacks.filter(
+          (f: string) => !String(f).startsWith(prefix) && !String(f).includes(`/${prefix}`),
+        );
         if (cleaned.length !== defaults.model.fallbacks.length) {
           defaults.model.fallbacks = cleaned.length ? cleaned : undefined;
           changed = true;
@@ -754,10 +829,24 @@ function removePluginFromOpenClawConfig(): boolean {
       }
       if (!defaults.model.primary && !defaults.model.fallbacks) delete defaults.model;
     }
-    if (cfg.models?.providers?.[PROVIDER_ID]) {
-      delete cfg.models.providers[PROVIDER_ID];
-      if (Object.keys(cfg.models.providers || {}).length === 0) delete cfg.models.providers;
+    const providers = cfg.models?.providers as Record<string, any> | undefined;
+    if (providers?.[PROVIDER_ID]) {
+      const cursorBaseUrl = providers[PROVIDER_ID]?.baseUrl;
+      delete providers[PROVIDER_ID];
+      if (cursorBaseUrl) {
+        for (const [providerId, providerConfig] of Object.entries(providers)) {
+          if ((providerConfig as Record<string, any>)?.baseUrl === cursorBaseUrl && providerId.toLowerCase().includes("cursor")) {
+            delete providers[providerId];
+          }
+        }
+      }
+      if (Object.keys(providers).length === 0) delete cfg.models.providers;
       changed = true;
+    } else if (providers) {
+      changed = cleanupStaleCursorLocalAliasProviders(cfg) || changed;
+    }
+    if (cfg.models?.providers && Object.keys(cfg.models.providers).length === 0) {
+      delete cfg.models.providers;
     }
     if (changed) writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
     return changed;
@@ -998,6 +1087,19 @@ const plugin = {
       }
       if (isPluginsInstall && result.cursorPath) {
         api.logger.info("Run 'openclaw cursor-brain setup' to choose primary/fallback models (optional), then restart your gateway to start.");
+        const existingProviders = (config as any).models?.providers ?? {};
+        const providerExists = !!existingProviders[PROVIDER_ID];
+        applyOpenClawConfigMutation(api, (draft) => {
+          normalizePluginInstallRecordSource(draft);
+          if (applyDefaultAgentModel(draft, result.cursorModels, { providerExists })) {
+            const primary = (draft.agents?.defaults?.model as any)?.primary;
+            if (primary) api.logger.info(`Default model normalized to ${primary}`);
+          }
+        }, {
+          onError: (err) => {
+            api.logger.warn(`Could not normalize default model: ${err instanceof Error ? err.message : String(err)}`);
+          },
+        });
       }
 
       const proxyPort = parseProxyPort(pluginConfig.proxyPort);
@@ -1097,8 +1199,10 @@ const plugin = {
           clack.log.info(`MCP config:    ${getCursorMcpConfigPath()}`);
 
           const currentModel = (config.agents as any)?.defaults?.model;
-          const curPrimary = currentModel?.primary?.replace(`${PROVIDER_ID}/`, "");
-          const curFallbacks = (currentModel?.fallbacks as string[] | undefined)?.map((f: string) => f.replace(`${PROVIDER_ID}/`, ""));
+          const curPrimary = extractCursorLocalModelId(currentModel?.primary);
+          const curFallbacks = (currentModel?.fallbacks as string[] | undefined)
+            ?.map((f: string) => extractCursorLocalModelId(f))
+            .filter((f): f is string => !!f);
           const proxyPort = parseProxyPort(pluginConfig.proxyPort);
           const selection = await promptModelSelection(result.cursorModels, curPrimary, curFallbacks);
           if (selection) {

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ let lastProxyStartTime = 0;
 let healthCheckTimer: ReturnType<typeof setInterval> | null = null;
 /** Ensures only one startProxy run at a time (no concurrent kill+spawn from register + health + exit). */
 let startProxyInProgress = false;
-/** So we only show "gateway restart" outro once per process (avoid duplicate when both runInteractiveSetupInProcess and setup command run). */
+/** So we only show "gateway restart" outro once per process (setup command). */
 let gatewayRestartOutroShown = false;
 const MAX_PROXY_RESTARTS = 3;
 const PROXY_RESTART_DELAYS = [2000, 10000, 60000];
@@ -119,70 +119,6 @@ function computeFileHash(filePath: string): string {
     const content = readFileSync(filePath, "utf-8");
     return createHash("sha256").update(content).digest("hex").slice(0, 12);
   } catch { return "unknown"; }
-}
-
-/** Run interactive setup (model selection + plugin config) after register completes. */
-async function runInteractiveSetupInProcess(opts: {
-  pluginDir: string;
-  config: Record<string, any>;
-  pluginConfig: Record<string, unknown>;
-  result: { cursorPath: string; cursorModels: CursorModel[]; outputFormat: OutputFormat };
-  proxyPort: number;
-}): Promise<void> {
-  const clack = loadClack();
-  clack.intro(`Cursor Brain Setup (v${readPackageVersion(opts.pluginDir)})`);
-
-  const currentModel = (opts.config.agents as any)?.defaults?.model;
-  const curPrimary = currentModel?.primary?.replace(`${PROVIDER_ID}/`, "");
-  const curFallbacks = (currentModel?.fallbacks as string[] | undefined)?.map((f: string) => f.replace(`${PROVIDER_ID}/`, ""));
-
-  const selection = await promptModelSelection(opts.result.cursorModels, curPrimary, curFallbacks);
-  if (selection) {
-    try {
-      saveModelSelection(selection.primary, selection.fallbacks, opts.proxyPort, opts.result.cursorModels);
-      clack.log.success("Model configuration saved to openclaw.json (agents.defaults.model + providers)");
-    } catch (e: any) {
-      clack.log.error(`Could not save model config: ${e?.message ?? String(e)}`);
-    }
-  }
-
-  const configResult = await promptPluginConfig(opts.pluginConfig as Record<string, unknown>);
-  if (configResult) {
-    try {
-      mergePluginConfig(configResult);
-      clack.log.success("Plugin configuration saved to openclaw.json");
-    } catch (e: any) {
-      clack.log.error(`Could not save config: ${e?.message ?? String(e)}`);
-    }
-  }
-
-  try {
-    syncPluginInstallRecord({ installPath: opts.pluginDir, updateTimestamp: false, preservedConfig: configResult ?? undefined });
-  } catch {}
-
-  const savedSelection = selection;
-  const savedPluginConfig = configResult;
-  setImmediate(() => {
-    fixInstallRecordSourceOnDisk(opts.pluginDir);
-    if (savedSelection) saveModelSelection(savedSelection.primary, savedSelection.fallbacks, opts.proxyPort, opts.result.cursorModels);
-    if (savedPluginConfig) mergePluginConfig(savedPluginConfig);
-  });
-
-  if (!gatewayRestartOutroShown) {
-    gatewayRestartOutroShown = true;
-    clack.outro("Run `openclaw gateway restart` (or restart your gateway) to apply changes.");
-  }
-}
-
-function scheduleInteractiveSetupInProcess(
-  opts: Parameters<typeof runInteractiveSetupInProcess>[0],
-  logger: { warn: (msg: string) => void },
-) {
-  setImmediate(() => {
-    void runInteractiveSetupInProcess(opts).catch((e: any) => {
-      logger.warn(`Interactive setup failed: ${e?.message ?? String(e)}`);
-    });
-  });
 }
 
 function readPackageVersion(dir: string): string {
@@ -878,8 +814,7 @@ const plugin = {
       if (result.cursorPath && result.mcpConfigured) {
         api.logger.info("Cursor Brain setup complete");
       }
-      const runInteractiveSetup = isPluginsInstall && result.cursorPath && result.cursorModels.length > 0 && !!process.stdin.isTTY;
-      if (isPluginsInstall && result.cursorPath && !runInteractiveSetup) {
+      if (isPluginsInstall && result.cursorPath) {
         api.logger.info("Run 'openclaw cursor-brain setup' to choose primary/fallback models (optional), then restart your gateway to start.");
       }
 
@@ -925,9 +860,6 @@ const plugin = {
               }
             } catch (e: any) {
               api.logger.warn(`Could not set default model: ${e?.message ?? String(e)}`);
-            }
-            if (runInteractiveSetup) {
-              scheduleInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort }, api.logger);
             }
           } else {
             // Read fresh config from disk rather than using api.config snapshot,
@@ -980,19 +912,11 @@ const plugin = {
                 writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(patch, null, 2) + "\n");
                 api.logger.info(`Provider "${PROVIDER_ID}" synced (${discovered.length} models, port ${proxyPort})`);
                 doSyncInstallRecord();
-                if (runInteractiveSetup) {
-                  scheduleInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort }, api.logger);
-                } else {
-                  setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
-                }
+                setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
               } catch (err: any) {
                 api.logger.warn(`Could not write config: ${err?.message ?? String(err)}`);
                 doSyncInstallRecord();
-                if (runInteractiveSetup) {
-                  scheduleInteractiveSetupInProcess({ pluginDir, config, pluginConfig: pluginConfig as Record<string, unknown>, result, proxyPort }, api.logger);
-                } else {
-                  setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
-                }
+                setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
               }
             } else {
               api.runtime.config.writeConfigFile(patch as any).then(() => {

--- a/index.ts
+++ b/index.ts
@@ -345,6 +345,85 @@ function buildProviderConfig(port: number, cursorModels: CursorModel[]) {
   };
 }
 
+function normalizePluginInstallRecordSource(draft: Record<string, any>): void {
+  const installRecord = draft.plugins?.installs?.[PLUGIN_ID];
+  if (installRecord?.source === "tarball") installRecord.source = "archive";
+}
+
+function applyDefaultAgentModel(
+  draft: Record<string, any>,
+  discovered: CursorModel[],
+  options: { providerExists: boolean },
+): boolean {
+  const currentPrimary = (draft.agents?.defaults?.model as any)?.primary;
+  const shouldSetDefaultModel =
+    !options.providerExists ||
+    !currentPrimary ||
+    String(currentPrimary).startsWith(`${PROVIDER_ID}/`);
+  if (!shouldSetDefaultModel) return false;
+
+  const primary = (currentPrimary as string)?.replace(`${PROVIDER_ID}/`, "") || "auto";
+  const existingFallbacks = (draft.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
+  const fallbacks = existingFallbacks?.length
+    ? existingFallbacks
+    : discovered.filter((m) => m.id !== primary).map((m) => `${PROVIDER_ID}/${m.id}`);
+
+  const agents = draft.agents || {};
+  const defaults = agents.defaults || {};
+  defaults.model = { primary: `${PROVIDER_ID}/${primary}`, fallbacks };
+  agents.defaults = defaults;
+  draft.agents = agents;
+  return true;
+}
+
+function syncProviderToConfig(
+  draft: Record<string, any>,
+  proxyPort: number,
+  discovered: CursorModel[],
+  providerExists: boolean,
+): void {
+  const modelsSection = draft.models || {};
+  modelsSection.mode = "merge";
+  const providers = modelsSection.providers || {};
+  providers[PROVIDER_ID] = buildProviderConfig(proxyPort, discovered);
+  modelsSection.providers = providers;
+  draft.models = modelsSection;
+  normalizePluginInstallRecordSource(draft);
+  applyDefaultAgentModel(draft, discovered, { providerExists });
+}
+
+function applyOpenClawConfigMutation(
+  api: OpenClawPluginApi,
+  mutate: (draft: Record<string, any>) => void,
+  callbacks?: {
+    onSuccess?: () => void;
+    onError?: (err: unknown) => void;
+  },
+): void {
+  const mutateConfigFile = api.runtime?.config?.mutateConfigFile;
+  if (typeof mutateConfigFile === "function") {
+    mutateConfigFile({
+      afterWrite: { mode: "auto" },
+      mutate: (draft) => {
+        mutate(draft);
+      },
+    })
+      .then(() => callbacks?.onSuccess?.())
+      .catch((err: unknown) => callbacks?.onError?.(err));
+    return;
+  }
+
+  try {
+    let cfg: Record<string, any> = {};
+    try { cfg = JSON.parse(readFileSync(OPENCLAW_CONFIG_PATH, "utf-8")); } catch {}
+    mutate(cfg);
+    writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
+    callbacks?.onSuccess?.();
+  } catch (err) {
+    callbacks?.onError?.(err);
+  }
+}
+
 function autoSelectModels(
   models: CursorModel[],
   currentPrimary?: string,
@@ -841,78 +920,31 @@ const plugin = {
 
             if (providerUnchanged && providerExists) {
               api.logger.info(`Provider "${PROVIDER_ID}" unchanged (${discovered.length} models, port ${proxyPort})`);
-              doSyncInstallRecord();
-              // Still ensure default model is set when missing (e.g. config was overwritten or never set)
-              try {
-                let cfg: Record<string, any> = {};
-                try { cfg = JSON.parse(readFileSync(OPENCLAW_CONFIG_PATH, "utf-8")); } catch { /* ignore */ }
-                const currentPrimary = (cfg.agents?.defaults?.model as any)?.primary;
-                if (!currentPrimary || String(currentPrimary).startsWith(`${PROVIDER_ID}/`)) {
-                  const primary = (currentPrimary as string)?.replace(`${PROVIDER_ID}/`, "") || "auto";
-                  const existingFallbacks = (cfg.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
-                  const fallbacks = existingFallbacks?.length ? existingFallbacks : discovered.filter((m) => m.id !== primary).map((m) => `${PROVIDER_ID}/${m.id}`);
-                  const agents = cfg.agents || {};
-                  const defaults = agents.defaults || {};
-                  defaults.model = { primary: `${PROVIDER_ID}/${primary}`, fallbacks };
-                  agents.defaults = defaults;
-                  cfg.agents = agents;
-                  writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
-                  api.logger.info(`Default model set to ${PROVIDER_ID}/${primary}`);
+              applyOpenClawConfigMutation(api, (draft) => {
+                normalizePluginInstallRecordSource(draft);
+                if (applyDefaultAgentModel(draft, discovered, { providerExists: true })) {
+                  const primary = (draft.agents?.defaults?.model as any)?.primary;
+                  if (primary) api.logger.info(`Default model set to ${primary}`);
                 }
-              } catch (e: any) {
-                api.logger.warn(`Could not set default model: ${e?.message ?? String(e)}`);
-              }
-            } else {
-              // Read fresh config from disk rather than using api.config snapshot,
-              // which may contain stale plugins data (e.g. during install subprocess
-              // where the core has already updated plugins.installs on disk but
-              // api.config still holds the pre-update snapshot).
-              let freshConfig: Record<string, any> = {};
-              try { freshConfig = JSON.parse(readFileSync(OPENCLAW_CONFIG_PATH, "utf-8")); } catch { freshConfig = { ...config }; }
-
-              const patch: Record<string, unknown> = {
-                ...freshConfig,
-                models: {
-                  ...(freshConfig.models || {}),
-                  mode: "merge",
-                  providers: {
-                    ...(freshConfig.models?.providers || {}),
-                    [PROVIDER_ID]: newProviderConfig,
-                  },
+              }, {
+                onSuccess: doSyncInstallRecord,
+                onError: (err) => {
+                  api.logger.warn(`Could not set default model: ${err instanceof Error ? err.message : String(err)}`);
+                  doSyncInstallRecord();
                 },
-              };
-
-              const currentPrimary = (freshConfig.agents?.defaults?.model as any)?.primary;
-              const shouldSetDefaultModel =
-                !providerExists ||
-                !currentPrimary ||
-                String(currentPrimary).startsWith(`${PROVIDER_ID}/`);
-              if (shouldSetDefaultModel) {
-                const primary = (currentPrimary as string)?.replace(`${PROVIDER_ID}/`, "") || "auto";
-                const existingFallbacks = (freshConfig.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
-                const fallbacks = existingFallbacks?.length ? existingFallbacks : discovered.filter((m) => m.id !== primary).map((m) => `${PROVIDER_ID}/${m.id}`);
-                (patch as any).agents = {
-                  ...(freshConfig.agents || {}),
-                  defaults: {
-                    ...(freshConfig.agents?.defaults || {}),
-                    model: {
-                      primary: `${PROVIDER_ID}/${primary}`,
-                      fallbacks,
-                    },
-                  },
-                };
-              }
-
-              // Ensure OpenClaw-accepted source value (avoids config overwrite during install)
-              const patchInstallRecord = (patch as any).plugins?.installs?.[PLUGIN_ID];
-              if (patchInstallRecord?.source === "tarball") patchInstallRecord.source = "archive";
-
-              api.runtime.config.writeConfigFile(patch as any).then(() => {
-                api.logger.info(`Provider "${PROVIDER_ID}" synced (${discovered.length} models, port ${proxyPort})`);
-                doSyncInstallRecord();
-              }).catch((err: any) => {
-                api.logger.warn(`Could not write config: ${err?.message ?? String(err)}`);
-                doSyncInstallRecord();
+              });
+            } else {
+              applyOpenClawConfigMutation(api, (draft) => {
+                syncProviderToConfig(draft, proxyPort, discovered, providerExists);
+              }, {
+                onSuccess: () => {
+                  api.logger.info(`Provider "${PROVIDER_ID}" synced (${discovered.length} models, port ${proxyPort})`);
+                  doSyncInstallRecord();
+                },
+                onError: (err) => {
+                  api.logger.warn(`Could not write config: ${err instanceof Error ? err.message : String(err)}`);
+                  doSyncInstallRecord();
+                },
               });
             }
           } catch (e: any) {

--- a/index.ts
+++ b/index.ts
@@ -523,11 +523,17 @@ function applyTuiFeedbackDefaults(draft: Record<string, any>): boolean {
   const currentInstant = config.instantResult;
   if (currentInstant === undefined || (legacyUntouched && currentInstant === true)) {
     config.instantResult = false;
+    changed = true;
+  }
+  if (config.forwardTools == null) {
+    config.forwardTools = "content";
+    changed = true;
+  }
+  if (changed) {
     entry.config = config;
     entries[PLUGIN_ID] = entry;
     plugins.entries = entries;
     draft.plugins = plugins;
-    changed = true;
   }
 
   return changed;

--- a/index.ts
+++ b/index.ts
@@ -853,7 +853,8 @@ const plugin = {
     const isUninstalling = isCursorBrainUninstallOrUpgrade;
     const isProxyCmd = /\bcursor-brain\s+proxy\b/.test(argv);
     const isSetupOnly = process.argv.includes("cursor-brain") && process.argv.includes("setup");
-    const isReadOnlyCliCmd = /\bcursor-brain\s+(doctor|status)\b/.test(argv);
+    const registrationMode = api.registrationMode;
+    const shouldRunActivationSetup = !isUninstalling && (registrationMode === "full" || isPluginsInstall);
 
     // Fix invalid source value on disk immediately so OpenClaw config validation won't overwrite
     if (!isPluginsInstall) {
@@ -875,7 +876,7 @@ const plugin = {
     const config = api.config;
     const pluginConfig = api.pluginConfig || {};
 
-    if (!isUninstalling && !isReadOnlyCliCmd) {
+    if (shouldRunActivationSetup) {
       const ctx: SetupContext = {
         pluginDir,
         gatewayPort: config.gateway?.port ?? 18789,
@@ -961,7 +962,7 @@ const plugin = {
       const effectiveCursorPath = result.cursorPath || detectCursorPath(pluginConfig.cursorPath as string | undefined);
       const effectiveOutputFormat =
         result.outputFormat ?? (effectiveCursorPath ? detectOutputFormat(effectiveCursorPath, pluginConfig.outputFormat as string | undefined) : undefined);
-      if (effectiveCursorPath && !isProxyCmd && !isPluginsInstall && !isSetupOnly && !isReadOnlyCliCmd) {
+      if (effectiveCursorPath && shouldRunActivationSetup && !isProxyCmd && !isPluginsInstall && !isSetupOnly) {
         const proxyOpts = {
           pluginDir,
           cursorPath: effectiveCursorPath,

--- a/index.ts
+++ b/index.ts
@@ -147,7 +147,6 @@ function compareSemver(a: string, b: string): number {
  */
 const PLUGIN_CONFIG_EXCLUDE_KEYS = new Set(["model", "fallbackModel"]);
 
-/** Build minimal env for proxy child to avoid spreading full process.env (reduces security-scan "env + network" warning). */
 function buildProxyChildEnv(vars: {
   CURSOR_PATH: string;
   CURSOR_WORKSPACE_DIR: string;
@@ -170,6 +169,86 @@ function buildProxyChildEnv(vars: {
     env.TEMP = e.TEMP ?? e.TMP ?? "";
   }
   return env;
+}
+
+function stopStreamingProxy(port: number): void {
+  if (healthCheckTimer) {
+    clearInterval(healthCheckTimer);
+    healthCheckTimer = null;
+  }
+  proxyRestartScheduled = false;
+  if (proxyChild) {
+    try { proxyChild.kill("SIGKILL"); } catch { /* process may already be dead */ }
+    proxyChild = null;
+  }
+  try {
+    if (existsSync(CURSOR_PROXY_PID_PATH)) {
+      const pidStr = readFileSync(CURSOR_PROXY_PID_PATH, "utf-8").trim();
+      const pid = parseInt(pidStr, 10);
+      if (Number.isFinite(pid) && pid > 0) killPidBySubprocess(pid);
+      rmSync(CURSOR_PROXY_PID_PATH, { force: true });
+    }
+  } catch { /* best-effort */ }
+  killPortProcess(port, "SIGKILL");
+}
+
+function spawnDetachedStreamingProxy(params: {
+  pluginDir: string;
+  cursorPath: string;
+  workspaceDir: string;
+  port: number;
+  outputFormat: OutputFormat;
+}): number | undefined {
+  const proxyScript = join(params.pluginDir, "mcp-server", "streaming-proxy.mjs");
+  if (!existsSync(proxyScript)) return undefined;
+  const child = spawn("node", [proxyScript], {
+    env: buildProxyChildEnv({
+      CURSOR_PATH: params.cursorPath,
+      CURSOR_WORKSPACE_DIR: params.workspaceDir,
+      CURSOR_PROXY_PORT: String(params.port),
+      CURSOR_OUTPUT_FORMAT: params.outputFormat,
+      CURSOR_PROXY_SCRIPT_HASH: computeFileHash(proxyScript),
+    }),
+    stdio: "ignore",
+    detached: true,
+  });
+  child.unref();
+  return child.pid;
+}
+
+function ensureStreamingProxyManaged(opts: {
+  pluginDir: string;
+  cursorPath: string;
+  workspaceDir: string;
+  port: number;
+  outputFormat: OutputFormat;
+  logger: any;
+}): void {
+  proxyChild = null;
+  const proxyRunning = isProxyRunning(opts.port);
+  let needRestart = !proxyRunning;
+
+  if (proxyRunning) {
+    const health = fetchProxyHealth(opts.port, 3000);
+    if (health) {
+      const proxyScript = join(opts.pluginDir, "mcp-server", "streaming-proxy.mjs");
+      const installedHash = computeFileHash(proxyScript);
+      if (health.scriptHash !== installedHash) {
+        opts.logger.info(`Proxy script changed (running=${health.scriptHash}, installed=${installedHash}), restarting...`);
+        needRestart = true;
+      }
+    } else {
+      needRestart = true;
+    }
+  }
+
+  if (needRestart) {
+    startProxy(opts);
+    return;
+  }
+
+  opts.logger.info(`Adopting proxy on port ${opts.port} — killing and restarting under this gateway`);
+  startProxy(opts);
 }
 
 /**
@@ -851,8 +930,6 @@ const plugin = {
       process.argv.includes("cursor-brain") &&
       process.argv.some((a) => a === "uninstall" || a === "upgrade");
     const isUninstalling = isCursorBrainUninstallOrUpgrade;
-    const isProxyCmd = /\bcursor-brain\s+proxy\b/.test(argv);
-    const isSetupOnly = process.argv.includes("cursor-brain") && process.argv.includes("setup");
     const registrationMode = api.registrationMode;
     const shouldRunActivationSetup = !isUninstalling && (registrationMode === "full" || isPluginsInstall);
 
@@ -875,6 +952,31 @@ const plugin = {
     const pluginDir = resolvePluginDir(api);
     const config = api.config;
     const pluginConfig = api.pluginConfig || {};
+
+    if (!isUninstalling) {
+      const proxyPort = parseProxyPort(pluginConfig.proxyPort);
+      api.registerService?.({
+        id: "cursor-brain-streaming-proxy",
+        start: async (ctx) => {
+          const cursorPath = detectCursorPath(pluginConfig.cursorPath as string | undefined);
+          if (!cursorPath) {
+            ctx.logger.warn("Cursor Agent not found; streaming proxy not started");
+            return;
+          }
+          ensureStreamingProxyManaged({
+            pluginDir,
+            cursorPath,
+            workspaceDir: ctx.workspaceDir ?? (config.agents as any)?.defaults?.workspace ?? "",
+            port: proxyPort,
+            outputFormat: detectOutputFormat(cursorPath, pluginConfig.outputFormat as string | undefined),
+            logger: ctx.logger,
+          });
+        },
+        stop: async () => {
+          stopStreamingProxy(proxyPort);
+        },
+      });
+    }
 
     if (shouldRunActivationSetup) {
       const ctx: SetupContext = {
@@ -955,51 +1057,6 @@ const plugin = {
           }
         } else {
           doSyncInstallRecord();
-        }
-      }
-
-      // On gateway restart we want proxy to start: use result.cursorPath or fallback to config so proxy always comes up when not in install/setup/uninstall.
-      const effectiveCursorPath = result.cursorPath || detectCursorPath(pluginConfig.cursorPath as string | undefined);
-      const effectiveOutputFormat =
-        result.outputFormat ?? (effectiveCursorPath ? detectOutputFormat(effectiveCursorPath, pluginConfig.outputFormat as string | undefined) : undefined);
-      if (effectiveCursorPath && shouldRunActivationSetup && !isProxyCmd && !isPluginsInstall && !isSetupOnly) {
-        const proxyOpts = {
-          pluginDir,
-          cursorPath: effectiveCursorPath,
-          workspaceDir: ctx.workspaceDir,
-          port: proxyPort,
-          outputFormat: effectiveOutputFormat ?? ("stream-json" as OutputFormat),
-          logger: api.logger,
-        };
-
-        // Don't trust in-memory proxyChild when register() runs: on any platform (macOS LaunchAgent,
-        // Linux systemd, Windows service), gateway "restart" may reload in-place (same process).
-        // Re-adopt whatever is on the port so proxy is owned by this process on all platforms.
-        proxyChild = null;
-
-        const proxyRunning = isProxyRunning(proxyPort);
-        let needRestart = !proxyRunning;
-
-        if (proxyRunning) {
-          const health = fetchProxyHealth(proxyPort, 3000);
-          if (health) {
-            const proxyScript = join(pluginDir, "mcp-server", "streaming-proxy.mjs");
-            const installedHash = computeFileHash(proxyScript);
-            if (health.scriptHash !== installedHash) {
-              api.logger.info(`Proxy script changed (running=${health.scriptHash}, installed=${installedHash}), restarting...`);
-              needRestart = true;
-            }
-          } else {
-            needRestart = true;
-          }
-        }
-
-        if (needRestart) {
-          startProxy(proxyOpts);
-        } else {
-          // Proxy is on port; we cleared proxyChild so we always adopt (kill + start) and own the process.
-          api.logger.info(`Adopting proxy on port ${proxyPort} — killing and restarting under this gateway`);
-          startProxy(proxyOpts);
         }
       }
     }
@@ -1406,17 +1463,47 @@ const plugin = {
         .description("Manage the streaming proxy process");
 
       proxyCmd
-        .action(() => {
+        .action(async () => {
           const proxyPort = parseProxyPort(pluginConfig.proxyPort);
           let up = false;
           let pid = "";
           let sessions = "";
-          const health = fetchProxyHealth(proxyPort);
+          let health = fetchProxyHealth(proxyPort);
           if (health) {
             up = health.status === "ok" || health.status === "degraded";
             sessions = String(health.sessions ?? "?");
           }
-          if (up) {
+
+          if (!up) {
+            const cursorPath = detectCursorPath(pluginConfig.cursorPath as string | undefined);
+            if (!cursorPath) {
+              console.error("Cannot start proxy: cursor-agent not found.");
+              process.exit(1);
+            }
+            const startedPid = spawnDetachedStreamingProxy({
+              pluginDir,
+              cursorPath,
+              workspaceDir: (config.agents as any)?.defaults?.workspace ?? "",
+              port: proxyPort,
+              outputFormat: detectOutputFormat(cursorPath, pluginConfig.outputFormat as string | undefined),
+            });
+            if (!startedPid) {
+              console.error("Cannot start proxy: streaming-proxy.mjs not found.");
+              process.exit(1);
+            }
+            for (let i = 0; i < 10; i++) {
+              await new Promise((r) => setTimeout(r, 500));
+              health = fetchProxyHealth(proxyPort);
+              if (health && (health.status === "ok" || health.status === "degraded")) break;
+            }
+            if (health) {
+              up = health.status === "ok" || health.status === "degraded";
+              sessions = String(health.sessions ?? "?");
+              pid = String(startedPid);
+            }
+          }
+
+          if (up && !pid) {
             try {
               if (process.platform === "win32") {
                 const out = execSync(`netstat -ano | findstr :${proxyPort} | findstr LISTENING`, {
@@ -1434,6 +1521,11 @@ const plugin = {
           if (pid) console.log(`  PID:       ${pid}`);
           if (sessions) console.log(`  Sessions:  ${sessions}`);
           console.log(`  Log file:  ${CURSOR_PROXY_LOG_PATH}`);
+          if (!up) {
+            console.log("\n  Proxy failed to start. Try: openclaw cursor-brain proxy restart");
+            console.log("  Gateway-managed proxy starts automatically after: openclaw gateway restart");
+          }
+          process.exit(up ? 0 : 1);
         });
 
       proxyCmd
@@ -1471,14 +1563,7 @@ const plugin = {
           const cursorPath = detectCursorPath(pluginConfig.cursorPath as string | undefined);
           if (!cursorPath) {
             console.error("Cannot restart: cursor-agent not found.");
-            process.exitCode = 1;
-            return;
-          }
-          const proxyScript = join(pluginDir, "mcp-server", "streaming-proxy.mjs");
-          if (!existsSync(proxyScript)) {
-            console.error(`Cannot restart: proxy script not found at ${proxyScript}`);
-            process.exitCode = 1;
-            return;
+            process.exit(1);
           }
 
           if (isProxyRunning(proxyPort)) {
@@ -1487,20 +1572,19 @@ const plugin = {
             try { if (existsSync(CURSOR_PROXY_PID_PATH)) rmSync(CURSOR_PROXY_PID_PATH, { force: true }); } catch { /* best-effort remove PID file */ }
           }
 
-          const outputFormat = detectOutputFormat(cursorPath, pluginConfig.outputFormat as string | undefined);
-          const child = spawn("node", [proxyScript], {
-            env: buildProxyChildEnv({
-              CURSOR_PATH: cursorPath,
-              CURSOR_WORKSPACE_DIR: (config.agents as any)?.defaults?.workspace ?? "",
-              CURSOR_PROXY_PORT: String(proxyPort),
-              CURSOR_OUTPUT_FORMAT: outputFormat,
-              CURSOR_PROXY_SCRIPT_HASH: computeFileHash(proxyScript),
-            }),
-            stdio: "ignore",
-            detached: true,
+          const pid = spawnDetachedStreamingProxy({
+            pluginDir,
+            cursorPath,
+            workspaceDir: (config.agents as any)?.defaults?.workspace ?? "",
+            port: proxyPort,
+            outputFormat: detectOutputFormat(cursorPath, pluginConfig.outputFormat as string | undefined),
           });
-          child.unref();
-          console.log(`Proxy restarted on port ${proxyPort} (pid ${child.pid}).`);
+          if (!pid) {
+            console.error(`Cannot restart: proxy script not found in ${join(pluginDir, "mcp-server")}`);
+            process.exit(1);
+          }
+          console.log(`Proxy restarted on port ${proxyPort} (pid ${pid}).`);
+          process.exit(0);
         });
 
       proxyCmd

--- a/index.ts
+++ b/index.ts
@@ -766,35 +766,34 @@ const plugin = {
   configSchema: loadPluginConfigSchema(),
 
   register(api: OpenClawPluginApi) {
-    // Fix invalid source value on disk immediately so OpenClaw config validation won't overwrite
-    try {
-      if (existsSync(OPENCLAW_CONFIG_PATH)) {
-        const raw = readFileSync(OPENCLAW_CONFIG_PATH, "utf-8");
-        const cfg = JSON.parse(raw);
-        const rec = cfg?.plugins?.installs?.[PLUGIN_ID];
-        if (rec && rec.source && !VALID_SOURCES.includes(rec.source as any)) {
-          rec.source = rec.source === "tarball" ? "archive" : "path";
-          if (rec.source === "path" && rec.installPath) rec.sourcePath = resolve(rec.installPath);
-          writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
-        }
-      }
-    } catch { /* ignore */ }
-
-    const pluginDir = resolvePluginDir(api);
-    const config = api.config;
-    const pluginConfig = api.pluginConfig || {};
-
-    // Only skip setup when user runs our CLI uninstall/upgrade; "openclaw plugins upgrade" should still run register setup
+    const argv = process.argv.join(" ");
+    const isPluginsInstall = process.argv.includes("plugins") && process.argv.includes("install");
     const isCursorBrainUninstallOrUpgrade =
       process.argv.includes("cursor-brain") &&
       process.argv.some((a) => a === "uninstall" || a === "upgrade");
     const isUninstalling = isCursorBrainUninstallOrUpgrade;
-    const argv = process.argv.join(" ");
     const isProxyCmd = /\bcursor-brain\s+proxy\b/.test(argv);
-    // During "openclaw plugins install", do not start proxy or timers so the install process can exit
-    const isPluginsInstall = process.argv.includes("plugins") && process.argv.includes("install");
-    // When running "cursor-brain setup" (standalone or as install child), skip starting proxy; user will "gateway restart" to get proxy
     const isSetupOnly = process.argv.includes("cursor-brain") && process.argv.includes("setup");
+
+    // Fix invalid source value on disk immediately so OpenClaw config validation won't overwrite
+    if (!isPluginsInstall) {
+      try {
+        if (existsSync(OPENCLAW_CONFIG_PATH)) {
+          const raw = readFileSync(OPENCLAW_CONFIG_PATH, "utf-8");
+          const cfg = JSON.parse(raw);
+          const rec = cfg?.plugins?.installs?.[PLUGIN_ID];
+          if (rec && rec.source && !VALID_SOURCES.includes(rec.source as any)) {
+            rec.source = rec.source === "tarball" ? "archive" : "path";
+            if (rec.source === "path" && rec.installPath) rec.sourcePath = resolve(rec.installPath);
+            writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
+          }
+        }
+      } catch { /* ignore */ }
+    }
+
+    const pluginDir = resolvePluginDir(api);
+    const config = api.config;
+    const pluginConfig = api.pluginConfig || {};
 
     if (!isUninstalling) {
       const ctx: SetupContext = {
@@ -819,106 +818,95 @@ const plugin = {
       }
 
       const proxyPort = parseProxyPort(pluginConfig.proxyPort);
-      const existingProviders = (config as any).models?.providers ?? {};
-      const discovered = result.cursorModels;
-      const providerExists = !!existingProviders[PROVIDER_ID];
 
-      const doSyncInstallRecord = () => {
-        try {
-          syncPluginInstallRecord({ installPath: pluginDir, updateTimestamp: false });
-        } catch (e: any) {
-          api.logger.warn(`Could not sync install record: ${e?.message ?? String(e)}`);
-        }
-      };
+      if (!isPluginsInstall) {
+        const existingProviders = (config as any).models?.providers ?? {};
+        const discovered = result.cursorModels;
+        const providerExists = !!existingProviders[PROVIDER_ID];
 
-      if (result.cursorPath) {
-        try {
-          const newProviderConfig = buildProviderConfig(proxyPort, discovered);
-          const existingProvider = existingProviders[PROVIDER_ID];
-          const providerUnchanged = existingProvider &&
-            JSON.stringify(existingProvider) === JSON.stringify(newProviderConfig);
+        const doSyncInstallRecord = () => {
+          try {
+            syncPluginInstallRecord({ installPath: pluginDir, updateTimestamp: false });
+          } catch (e: any) {
+            api.logger.warn(`Could not sync install record: ${e?.message ?? String(e)}`);
+          }
+        };
 
-          if (providerUnchanged && providerExists) {
-            api.logger.info(`Provider "${PROVIDER_ID}" unchanged (${discovered.length} models, port ${proxyPort})`);
-            doSyncInstallRecord();
-            // Still ensure default model is set when missing (e.g. config was overwritten or never set)
-            try {
-              let cfg: Record<string, any> = {};
-              try { cfg = JSON.parse(readFileSync(OPENCLAW_CONFIG_PATH, "utf-8")); } catch { /* ignore */ }
-              const currentPrimary = (cfg.agents?.defaults?.model as any)?.primary;
-              if (!currentPrimary || String(currentPrimary).startsWith(`${PROVIDER_ID}/`)) {
-                const primary = (currentPrimary as string)?.replace(`${PROVIDER_ID}/`, "") || "auto";
-                const existingFallbacks = (cfg.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
-                const fallbacks = existingFallbacks?.length ? existingFallbacks : discovered.filter((m) => m.id !== primary).map((m) => `${PROVIDER_ID}/${m.id}`);
-                const agents = cfg.agents || {};
-                const defaults = agents.defaults || {};
-                defaults.model = { primary: `${PROVIDER_ID}/${primary}`, fallbacks };
-                agents.defaults = defaults;
-                cfg.agents = agents;
-                writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
-                api.logger.info(`Default model set to ${PROVIDER_ID}/${primary}`);
+        if (result.cursorPath) {
+          try {
+            const newProviderConfig = buildProviderConfig(proxyPort, discovered);
+            const existingProvider = existingProviders[PROVIDER_ID];
+            const providerUnchanged = existingProvider &&
+              JSON.stringify(existingProvider) === JSON.stringify(newProviderConfig);
+
+            if (providerUnchanged && providerExists) {
+              api.logger.info(`Provider "${PROVIDER_ID}" unchanged (${discovered.length} models, port ${proxyPort})`);
+              doSyncInstallRecord();
+              // Still ensure default model is set when missing (e.g. config was overwritten or never set)
+              try {
+                let cfg: Record<string, any> = {};
+                try { cfg = JSON.parse(readFileSync(OPENCLAW_CONFIG_PATH, "utf-8")); } catch { /* ignore */ }
+                const currentPrimary = (cfg.agents?.defaults?.model as any)?.primary;
+                if (!currentPrimary || String(currentPrimary).startsWith(`${PROVIDER_ID}/`)) {
+                  const primary = (currentPrimary as string)?.replace(`${PROVIDER_ID}/`, "") || "auto";
+                  const existingFallbacks = (cfg.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
+                  const fallbacks = existingFallbacks?.length ? existingFallbacks : discovered.filter((m) => m.id !== primary).map((m) => `${PROVIDER_ID}/${m.id}`);
+                  const agents = cfg.agents || {};
+                  const defaults = agents.defaults || {};
+                  defaults.model = { primary: `${PROVIDER_ID}/${primary}`, fallbacks };
+                  agents.defaults = defaults;
+                  cfg.agents = agents;
+                  writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
+                  api.logger.info(`Default model set to ${PROVIDER_ID}/${primary}`);
+                }
+              } catch (e: any) {
+                api.logger.warn(`Could not set default model: ${e?.message ?? String(e)}`);
               }
-            } catch (e: any) {
-              api.logger.warn(`Could not set default model: ${e?.message ?? String(e)}`);
-            }
-          } else {
-            // Read fresh config from disk rather than using api.config snapshot,
-            // which may contain stale plugins data (e.g. during install subprocess
-            // where the core has already updated plugins.installs on disk but
-            // api.config still holds the pre-update snapshot).
-            let freshConfig: Record<string, any> = {};
-            try { freshConfig = JSON.parse(readFileSync(OPENCLAW_CONFIG_PATH, "utf-8")); } catch { freshConfig = { ...config }; }
+            } else {
+              // Read fresh config from disk rather than using api.config snapshot,
+              // which may contain stale plugins data (e.g. during install subprocess
+              // where the core has already updated plugins.installs on disk but
+              // api.config still holds the pre-update snapshot).
+              let freshConfig: Record<string, any> = {};
+              try { freshConfig = JSON.parse(readFileSync(OPENCLAW_CONFIG_PATH, "utf-8")); } catch { freshConfig = { ...config }; }
 
-            const patch: Record<string, unknown> = {
-              ...freshConfig,
-              models: {
-                ...(freshConfig.models || {}),
-                mode: "merge",
-                providers: {
-                  ...(freshConfig.models?.providers || {}),
-                  [PROVIDER_ID]: newProviderConfig,
-                },
-              },
-            };
-
-            const currentPrimary = (freshConfig.agents?.defaults?.model as any)?.primary;
-            const shouldSetDefaultModel =
-              !providerExists ||
-              !currentPrimary ||
-              String(currentPrimary).startsWith(`${PROVIDER_ID}/`);
-            if (shouldSetDefaultModel) {
-              const primary = (currentPrimary as string)?.replace(`${PROVIDER_ID}/`, "") || "auto";
-              const existingFallbacks = (freshConfig.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
-              const fallbacks = existingFallbacks?.length ? existingFallbacks : discovered.filter((m) => m.id !== primary).map((m) => `${PROVIDER_ID}/${m.id}`);
-              (patch as any).agents = {
-                ...(freshConfig.agents || {}),
-                defaults: {
-                  ...(freshConfig.agents?.defaults || {}),
-                  model: {
-                    primary: `${PROVIDER_ID}/${primary}`,
-                    fallbacks,
+              const patch: Record<string, unknown> = {
+                ...freshConfig,
+                models: {
+                  ...(freshConfig.models || {}),
+                  mode: "merge",
+                  providers: {
+                    ...(freshConfig.models?.providers || {}),
+                    [PROVIDER_ID]: newProviderConfig,
                   },
                 },
               };
-            }
 
-            // Ensure OpenClaw-accepted source value (avoids config overwrite during install)
-            const patchInstallRecord = (patch as any).plugins?.installs?.[PLUGIN_ID];
-            if (patchInstallRecord?.source === "tarball") patchInstallRecord.source = "archive";
-
-            if (isPluginsInstall) {
-              try {
-                mkdirSync(dirname(OPENCLAW_CONFIG_PATH), { recursive: true });
-                writeFileSync(OPENCLAW_CONFIG_PATH, JSON.stringify(patch, null, 2) + "\n");
-                api.logger.info(`Provider "${PROVIDER_ID}" synced (${discovered.length} models, port ${proxyPort})`);
-                doSyncInstallRecord();
-                setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
-              } catch (err: any) {
-                api.logger.warn(`Could not write config: ${err?.message ?? String(err)}`);
-                doSyncInstallRecord();
-                setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
+              const currentPrimary = (freshConfig.agents?.defaults?.model as any)?.primary;
+              const shouldSetDefaultModel =
+                !providerExists ||
+                !currentPrimary ||
+                String(currentPrimary).startsWith(`${PROVIDER_ID}/`);
+              if (shouldSetDefaultModel) {
+                const primary = (currentPrimary as string)?.replace(`${PROVIDER_ID}/`, "") || "auto";
+                const existingFallbacks = (freshConfig.agents?.defaults?.model as any)?.fallbacks as string[] | undefined;
+                const fallbacks = existingFallbacks?.length ? existingFallbacks : discovered.filter((m) => m.id !== primary).map((m) => `${PROVIDER_ID}/${m.id}`);
+                (patch as any).agents = {
+                  ...(freshConfig.agents || {}),
+                  defaults: {
+                    ...(freshConfig.agents?.defaults || {}),
+                    model: {
+                      primary: `${PROVIDER_ID}/${primary}`,
+                      fallbacks,
+                    },
+                  },
+                };
               }
-            } else {
+
+              // Ensure OpenClaw-accepted source value (avoids config overwrite during install)
+              const patchInstallRecord = (patch as any).plugins?.installs?.[PLUGIN_ID];
+              if (patchInstallRecord?.source === "tarball") patchInstallRecord.source = "archive";
+
               api.runtime.config.writeConfigFile(patch as any).then(() => {
                 api.logger.info(`Provider "${PROVIDER_ID}" synced (${discovered.length} models, port ${proxyPort})`);
                 doSyncInstallRecord();
@@ -927,15 +915,13 @@ const plugin = {
                 doSyncInstallRecord();
               });
             }
+          } catch (e: any) {
+            api.logger.warn(`Could not auto-configure: ${e?.message ?? String(e)}`);
+            doSyncInstallRecord();
           }
-        } catch (e: any) {
-          api.logger.warn(`Could not auto-configure: ${e?.message ?? String(e)}`);
+        } else {
           doSyncInstallRecord();
-          if (isPluginsInstall) setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
         }
-      } else {
-        doSyncInstallRecord();
-        if (isPluginsInstall) setImmediate(() => fixInstallRecordSourceOnDisk(pluginDir));
       }
 
       // On gateway restart we want proxy to start: use result.cursorPath or fallback to config so proxy always comes up when not in install/setup/uninstall.

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { existsSync, readFileSync, writeFileSync, appendFileSync, rmSync, realpathSync, mkdirSync, cpSync } from "fs";
 import { createHash } from "crypto";
 import { join, resolve, dirname, isAbsolute } from "path";
+import { fileURLToPath } from "url";
 import { homedir } from "os";
 import { execSync, spawn, spawnSync } from "child_process";
 import { createRequire } from "module";
@@ -25,9 +26,21 @@ const HEALTH_CHECK_INTERVAL = 60000; // 60s
 
 // @clack/prompts lives in openclaw's node_modules; follow the bin symlink to resolve
 let _clack: any;
+function resolvePluginRootFromModule(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  if (existsSync(join(moduleDir, "package.json"))) {
+    return moduleDir;
+  }
+  const parentDir = join(moduleDir, "..");
+  if (existsSync(join(parentDir, "package.json"))) {
+    return parentDir;
+  }
+  return moduleDir;
+}
+
 function loadClack() {
   if (_clack) return _clack;
-  let entry = process.argv[1] || __filename;
+  let entry = process.argv[1] || fileURLToPath(import.meta.url);
   try { entry = realpathSync(entry); } catch {}
   _clack = createRequire(entry)("@clack/prompts");
   return _clack;
@@ -783,7 +796,7 @@ function resolvePluginDir(api: OpenClawPluginApi): string {
 /** Load configSchema from openclaw.plugin.json so the host shows all options (e.g. requestTimeout, proxy) in config UI; fallback to empty if manifest missing. */
 function loadPluginConfigSchema(): Record<string, unknown> {
   try {
-    const pluginDir = dirname(createRequire(import.meta.url).resolve("./package.json"));
+    const pluginDir = resolvePluginRootFromModule();
     const manifestPath = join(pluginDir, "openclaw.plugin.json");
     if (!existsSync(manifestPath)) return emptyPluginConfigSchema();
     const raw = readFileSync(manifestPath, "utf-8");

--- a/index.ts
+++ b/index.ts
@@ -496,6 +496,43 @@ function cleanupStaleCursorLocalAliasProviders(draft: Record<string, any>): bool
   return changed;
 }
 
+function applyTuiFeedbackDefaults(draft: Record<string, any>): boolean {
+  let changed = false;
+  const agents = draft.agents || {};
+  const defaults = agents.defaults || {};
+  const legacyUntouched = defaults.verboseDefault == null;
+
+  if (legacyUntouched) {
+    defaults.verboseDefault = "on";
+    defaults.reasoningDefault = "stream";
+    changed = true;
+  } else if (defaults.reasoningDefault == null) {
+    defaults.reasoningDefault = "stream";
+    changed = true;
+  }
+
+  if (changed) {
+    agents.defaults = defaults;
+    draft.agents = agents;
+  }
+
+  const plugins = draft.plugins || {};
+  const entries = plugins.entries || {};
+  const entry = entries[PLUGIN_ID] || {};
+  const config = { ...(entry.config || {}) } as Record<string, unknown>;
+  const currentInstant = config.instantResult;
+  if (currentInstant === undefined || (legacyUntouched && currentInstant === true)) {
+    config.instantResult = false;
+    entry.config = config;
+    entries[PLUGIN_ID] = entry;
+    plugins.entries = entries;
+    draft.plugins = plugins;
+    changed = true;
+  }
+
+  return changed;
+}
+
 function applyDefaultAgentModel(
   draft: Record<string, any>,
   discovered: CursorModel[],
@@ -516,15 +553,19 @@ function applyDefaultAgentModel(
     existingFallbacks.length !== normalizedFallbacks.length ||
     existingFallbacks.some((f, i) => f !== normalizedFallbacks[i]);
 
-  if (!shouldFixPrimary && !shouldFixFallbacks) return false;
+  let changed = false;
+  if (shouldFixPrimary || shouldFixFallbacks) {
+    const agents = draft.agents || {};
+    const defaults = agents.defaults || {};
+    defaults.model = { primary: normalizedPrimary, fallbacks: normalizedFallbacks };
+    agents.defaults = defaults;
+    draft.agents = agents;
+    cleanupStaleCursorLocalAliasProviders(draft);
+    changed = true;
+  }
 
-  const agents = draft.agents || {};
-  const defaults = agents.defaults || {};
-  defaults.model = { primary: normalizedPrimary, fallbacks: normalizedFallbacks };
-  agents.defaults = defaults;
-  draft.agents = agents;
-  cleanupStaleCursorLocalAliasProviders(draft);
-  return true;
+  if (applyTuiFeedbackDefaults(draft)) changed = true;
+  return changed;
 }
 
 function syncProviderToConfig(

--- a/mcp-server/streaming-proxy.mjs
+++ b/mcp-server/streaming-proxy.mjs
@@ -68,7 +68,7 @@ const RAW_FORWARD_THINKING = fromConfig("forwardThinking", "content", (v) => {
   return false; // "off", "false", or unknown
 });
 const FORWARD_THINKING = RAW_FORWARD_THINKING !== false;
-const INSTANT_RESULT = fromConfig("instantResult", true, (v) => v !== false && v !== "false");
+const INSTANT_RESULT = fromConfig("instantResult", false, (v) => v !== false && v !== "false");
 const TARGET_CHARS_PER_SEC = parseInt(fromConfig("streamSpeed", "200"), 10) || 200;
 const SHORT_TEXT_THRESHOLD = 100;
 const MIN_TIMEOUT_MS = 60_000;

--- a/mcp-server/streaming-proxy.mjs
+++ b/mcp-server/streaming-proxy.mjs
@@ -19,7 +19,7 @@ import http from "node:http";
 import { spawn, execSync } from "node:child_process";
 import { createInterface } from "node:readline";
 import { randomUUID, createHash } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, rmSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -156,8 +156,37 @@ const SCRIPT_HASH = process.env.CURSOR_PROXY_SCRIPT_HASH || computeScriptHash();
 
 // ── Cursor path auto-detection ──────────────────────────────────────────────
 
+function isCursorAgentBinary(cursorPath) {
+  if (!cursorPath || !existsSync(cursorPath)) return false;
+
+  try {
+    const resolved = realpathSync(cursorPath);
+    if (resolved.includes("cursor-agent")) return true;
+  } catch {
+    /* keep validating via --help */
+  }
+
+  try {
+    const output = execSync(`"${cursorPath}" --help`, {
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return output.includes("Start the Cursor Agent")
+      || output.includes("--list-models")
+      || output.includes("stream-json");
+  } catch (e) {
+    const combined = `${e.stdout || ""}${e.stderr || ""}`;
+    return combined.includes("Start the Cursor Agent")
+      || combined.includes("--list-models")
+      || combined.includes("stream-json");
+  }
+}
+
 function detectCursorPath() {
-  if (process.env.CURSOR_PATH) return process.env.CURSOR_PATH;
+  if (process.env.CURSOR_PATH && isCursorAgentBinary(process.env.CURSOR_PATH)) {
+    return process.env.CURSOR_PATH;
+  }
 
   const home = homedir();
   const isWin = process.platform === "win32";
@@ -169,21 +198,27 @@ function detectCursorPath() {
         join(home, ".cursor", "bin", "agent.exe"),
         join(home, ".cursor", "bin", "agent.cmd"),
         join(home, ".local", "bin", "agent.exe"),
+        join(home, ".local", "bin", "cursor-agent.exe"),
       ]
     : [
+        join(home, ".local", "bin", "cursor-agent"),
         join(home, ".local", "bin", "agent"),
-        "/usr/local/bin/agent",
+        join(home, ".cursor", "bin", "cursor-agent"),
         join(home, ".cursor", "bin", "agent"),
+        "/usr/local/bin/cursor-agent",
+        "/usr/local/bin/agent",
       ];
 
-  for (const p of candidates) {
-    if (existsSync(p)) return p;
+  for (const candidate of candidates) {
+    if (isCursorAgentBinary(candidate)) return candidate;
   }
 
   try {
-    const cmd = isWin ? "where agent 2>nul" : "which agent 2>/dev/null";
+    const cmd = isWin ? "where agent 2>nul" : "which -a agent 2>/dev/null";
     const result = execSync(cmd, { encoding: "utf-8", timeout: 3000 }).trim();
-    if (result && existsSync(result.split("\n")[0])) return result.split("\n")[0];
+    for (const line of [...new Set(result.split(/\r?\n/).map((entry) => entry.trim()).filter(Boolean))]) {
+      if (isCursorAgentBinary(line)) return line;
+    }
   } catch {}
 
   return "";

--- a/mcp-server/streaming-proxy.mjs
+++ b/mcp-server/streaming-proxy.mjs
@@ -68,9 +68,10 @@ const RAW_FORWARD_THINKING = fromConfig("forwardThinking", "content", (v) => {
   return false; // "off", "false", or unknown
 });
 const FORWARD_THINKING = RAW_FORWARD_THINKING !== false;
+const RAW_FORWARD_TOOLS = fromConfig("forwardTools", "content", (v) => (v === "content" ? "content" : false));
+const FORWARD_TOOLS = RAW_FORWARD_TOOLS === "content";
 const INSTANT_RESULT = fromConfig("instantResult", false, (v) => v !== false && v !== "false");
 const TARGET_CHARS_PER_SEC = parseInt(fromConfig("streamSpeed", "200"), 10) || 200;
-const SHORT_TEXT_THRESHOLD = 100;
 const MIN_TIMEOUT_MS = 60_000;
 const RAW_REQUEST_TIMEOUT_MS = parseInt(fromConfig("requestTimeout", "300000"), 10);
 const RAW_DEGRADED_TIMEOUT_MS = parseInt(fromConfig("degradedTimeout", "300000"), 10);
@@ -88,6 +89,42 @@ const THINKING_BODY_SEPARATOR = "\n\n---\n\n";
 function formatThinkingBlock(text) {
   if (!text || typeof text !== "string") return "";
   return "> 💭 " + text.trim().replace(/\n/g, "\n> ");
+}
+
+function summarizeToolArgs(args, maxLen = 160) {
+  if (args == null) return "";
+  try {
+    const serialized = JSON.stringify(args);
+    return serialized.length <= maxLen ? serialized : `${serialized.slice(0, maxLen)}…`;
+  } catch {
+    return String(args).slice(0, maxLen);
+  }
+}
+
+function summarizeToolResult(result, maxLen = 200) {
+  if (result == null) return "";
+  if (typeof result === "string") return result.length <= maxLen ? result : `${result.slice(0, maxLen)}…`;
+  try {
+    const serialized = JSON.stringify(result);
+    return serialized.length <= maxLen ? serialized : `${serialized.slice(0, maxLen)}…`;
+  } catch {
+    return String(result).slice(0, maxLen);
+  }
+}
+
+function formatToolStartBlock(toolName, args) {
+  const argsSummary = summarizeToolArgs(args);
+  const lines = [`> 🧰 **${toolName}** — running`];
+  if (argsSummary) lines.push(`> \`${argsSummary}\``);
+  return `${lines.join("\n")}\n\n`;
+}
+
+function formatToolDoneBlock(toolName, elapsedMs, ok, result) {
+  const status = ok === null ? "done" : ok ? "ok" : "failed";
+  const lines = [`> 🧰 **${toolName}** — ${status}${elapsedMs ? ` (${elapsedMs})` : ""}`];
+  const resultSummary = summarizeToolResult(result);
+  if (resultSummary) lines.push(`> \`${resultSummary}\``);
+  return `${lines.join("\n")}\n\n`;
 }
 
 // Prevent EPIPE from stderr (e.g. when gateway restarts and closes the pipe) from crashing the process.
@@ -342,11 +379,12 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-// ── Smart chunked streaming ─────────────────────────────────────────────────
+// ── Fallback chunked streaming (bulk result events only) ────────────────────
 
 async function streamChunked(res, id, model, text) {
   const len = text.length;
-  if (len <= SHORT_TEXT_THRESHOLD) {
+  if (len === 0) return;
+  if (INSTANT_RESULT) {
     res.write(sseEvent(id, model, { content: text }));
     return;
   }
@@ -358,6 +396,11 @@ async function streamChunked(res, id, model, text) {
     res.write(sseEvent(id, model, { content: text.slice(i, i + chunkSize) }));
     if (i + chunkSize < len) await sleep(delayMs);
   }
+}
+
+async function streamAnswerContent(res, id, model, text) {
+  if (!text) return;
+  await streamChunked(res, id, model, text);
 }
 
 // ── Spawn cursor-agent ──────────────────────────────────────────────────────
@@ -437,8 +480,8 @@ function ensureStreamHeaders(res, streamState) {
 /**
  * forwardThinking modes (first principles):
  * - off: do not forward thinking; stream only assistant "text" and final result.
- * - content: thinking appears in message body as markdown blockquote ("> 💭 ..."); separator "---" before body; stream thinking as content deltas, then resultText with "\n\n---\n\n" prefix if no "text" deltas were received.
- * - reasoning_content: thinking in separate field (delta.reasoning_content / message.reasoning_content); stream thinking as reasoning_content deltas, then resultText as content (no separator).
+ * - content: thinking appears in message body as markdown blockquote ("> 💭 ..."); separator "---" before body; stream thinking as content deltas, then live "text" deltas; bulk "result" only if no text deltas (chunked when instantResult is false).
+ * - reasoning_content: thinking in separate field (delta.reasoning_content / message.reasoning_content); stream thinking as reasoning_content deltas, then live "text" deltas; bulk "result" as content fallback (no separator).
  */
 function processStreamOutput(child, { requestId, model, sessionKey, res, streamState }) {
   return new Promise((resolve) => {
@@ -479,16 +522,28 @@ function processStreamOutput(child, { requestId, model, sessionKey, res, streamS
         const tc = parsed.tool_call || {};
         const toolKey = Object.keys(tc)[0] || "unknown";
         if (parsed.subtype === "started") {
-          toolCalls.set(callId, { tool: toolKey, startTime: Date.now() });
           const args = tc[toolKey]?.args;
-          const argsSummary = args ? JSON.stringify(args).slice(0, 120) : "";
+          toolCalls.set(callId, { tool: toolKey, startTime: Date.now(), args });
+          const argsSummary = args ? summarizeToolArgs(args, 120) : "";
           log("info", `[${requestId}] tool:start ${toolKey}${argsSummary ? ` args=${argsSummary}` : ""} (call_id=${callId})`);
+          if (FORWARD_TOOLS) {
+            hasStreamedContent = true;
+            if (streamState) ensureStreamHeaders(res, streamState);
+            res.write(sseEvent(requestId, model, { content: formatToolStartBlock(toolKey, args) }));
+          }
         } else if (parsed.subtype === "completed") {
           const tracked = toolCalls.get(callId);
           const elapsed = tracked ? `${Date.now() - tracked.startTime}ms` : "?ms";
           const result = tc[toolKey]?.result;
           const ok = result ? !!result.success : null;
           log("info", `[${requestId}] tool:done  ${tracked?.tool || toolKey} ${elapsed}${ok !== null ? ` ok=${ok}` : ""} (call_id=${callId})`);
+          if (FORWARD_TOOLS) {
+            hasStreamedContent = true;
+            if (streamState) ensureStreamHeaders(res, streamState);
+            res.write(sseEvent(requestId, model, {
+              content: formatToolDoneBlock(tracked?.tool || toolKey, elapsed, ok, result),
+            }));
+          }
           toolCalls.delete(callId);
         }
         return;
@@ -536,7 +591,7 @@ function processStreamOutput(child, { requestId, model, sessionKey, res, streamS
       }
 
       if (type === "result" && typeof parsed.result === "string") {
-        resultText = parsed.result;
+        if (!hasStreamedTextContent) resultText = parsed.result;
       }
     });
 
@@ -578,7 +633,7 @@ async function processStreamOutputWithTimeout(child, opts, effectiveTimeout) {
   }
 }
 
-// ── Streaming handler (real-time thinking + smart chunked result) ────────────
+// ── Streaming handler (live text deltas + chunked bulk-result fallback) ─────
 
 function resolveSessionKey(body, req) {
   if (body._openclaw_session_id) return { key: body._openclaw_session_id, src: "body._openclaw" };
@@ -714,23 +769,14 @@ async function handleStream(req, res, body) {
     if (canRetry) log("info", `[${requestId}] retry succeeded`);
     if (result.resultText && !result.hasStreamedContent) {
       ensureStreamHeaders(res, streamState);
-      if (INSTANT_RESULT) {
-        res.write(sseEvent(requestId, model, { content: result.resultText }));
-      } else {
-        await streamChunked(res, requestId, model, result.resultText);
-      }
+      await streamAnswerContent(res, requestId, model, result.resultText);
     } else if (result.resultText && result.hasStreamedContent && result.hasStreamedTextContent) {
-      log("debug", `[${requestId}] result received after text deltas, skipping duplicate`);
+      log("debug", `[${requestId}] bulk result after live text deltas, skipping duplicate`);
     } else if (result.resultText && result.hasStreamedContent && !result.hasStreamedTextContent) {
       ensureStreamHeaders(res, streamState);
       const separator = result.hasStreamedThinkingContent ? THINKING_BODY_SEPARATOR : "";
-      const contentToSend = separator + result.resultText;
-      if (INSTANT_RESULT) {
-        res.write(sseEvent(requestId, model, { content: contentToSend }));
-      } else {
-        await streamChunked(res, requestId, model, contentToSend);
-      }
-      log("debug", `[${requestId}] streamed result as content${result.hasStreamedThinkingContent ? " (after thinking, with --- separator)" : " (only reasoning_content was streamed before)"}`);
+      await streamAnswerContent(res, requestId, model, separator + result.resultText);
+      log("debug", `[${requestId}] streamed bulk result${result.hasStreamedThinkingContent ? " (after thinking, with --- separator)" : " (only reasoning_content was streamed before)"}${INSTANT_RESULT ? " instantly" : " via chunked fallback"}`);
     }
   }
 
@@ -1004,7 +1050,7 @@ function onListenSuccess() {
     writeFileSync(PROXY_PID_FILE, String(process.pid), "utf-8");
   } catch {}
   log("info", `Config file: ${openclawPath}`);
-  log("info", `Config (plugin ${PLUGIN_ID}): forwardThinking=${String(RAW_FORWARD_THINKING || "off")}, instantResult=${INSTANT_RESULT}, requestTimeout=${REQUEST_TIMEOUT_MS}, streamSpeed=${TARGET_CHARS_PER_SEC}, maxConsecutiveFailures=${MAX_CONSECUTIVE_FAILURES}, maxConsecutiveTimeouts=${MAX_CONSECUTIVE_TIMEOUTS}`);
+  log("info", `Config (plugin ${PLUGIN_ID}): forwardThinking=${String(RAW_FORWARD_THINKING || "off")}, forwardTools=${FORWARD_TOOLS ? "content" : "off"}, instantResult=${INSTANT_RESULT}, requestTimeout=${REQUEST_TIMEOUT_MS}, streamSpeed=${TARGET_CHARS_PER_SEC}, maxConsecutiveFailures=${MAX_CONSECUTIVE_FAILURES}, maxConsecutiveTimeouts=${MAX_CONSECUTIVE_TIMEOUTS}`);
   log("info", `Cursor streaming proxy on http://127.0.0.1:${PORT}`);
   if (CURSOR_PATH) {
     log("info", `Cursor agent: ${CURSOR_PATH}`);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -54,7 +54,7 @@
       "instantResult": {
         "type": "boolean",
         "default": false,
-        "description": "Send batch results instantly. When false, chunked streaming gives earlier TUI feedback. Proxy reads from openclaw.json."
+        "description": "Send bulk result events instantly. Answer text deltas always stream live; when false, a single final result event is replayed in chunks (~streamSpeed chars/sec). Proxy reads from openclaw.json."
       },
       "forwardThinking": {
         "type": "string",
@@ -66,10 +66,19 @@
         "default": "content",
         "description": "How to stream Cursor's thinking output. off: drop (not sent). content: send as normal content, markdown blockquote + \"---\" before reply (OpenClaw streaming cards). reasoning_content: send in the reasoning_content field (OpenAI-style). Proxy reads from openclaw.json."
       },
+      "forwardTools": {
+        "type": "string",
+        "enum": [
+          "off",
+          "content"
+        ],
+        "default": "content",
+        "description": "How to stream Cursor MCP tool invocations. off: proxy logs only. content: stream tool start/done as markdown blockquotes in the assistant message (visible in TUI while cursor-agent runs tools internally). Proxy reads from openclaw.json."
+      },
       "streamSpeed": {
         "type": "number",
         "default": 200,
-        "description": "Chunked streaming chars/sec when instantResult is false. Proxy reads from openclaw.json."
+        "description": "Fallback replay speed (chars/sec) for bulk result events when instantResult is false. Live text deltas ignore this. Proxy reads from openclaw.json."
       }
     }
   }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -53,8 +53,8 @@
       },
       "instantResult": {
         "type": "boolean",
-        "default": true,
-        "description": "Send batch results instantly. Proxy reads from openclaw.json."
+        "default": false,
+        "description": "Send batch results instantly. When false, chunked streaming gives earlier TUI feedback. Proxy reads from openclaw.json."
       },
       "forwardThinking": {
         "type": "string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-cursor-brain",
-  "version": "1.4.7",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-cursor-brain",
-      "version": "1.4.7",
+      "version": "1.5.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,24 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
+    "prepublishOnly": "npm run build",
     "uninstall": "node scripts/uninstall.mjs",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit"
   },
   "files": [
+    "dist/",
     "index.ts",
     "src/",
     "scripts/",
@@ -49,6 +61,9 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
+    ],
+    "runtimeExtensions": [
+      "./dist/index.js"
     ],
     "install": {
       "npmSpec": "openclaw-cursor-brain",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,17 +37,21 @@ export function getCursorSearchPaths(): string[] {
       join(home, ".cursor", "bin", "agent.exe"),
       join(home, ".cursor", "bin", "agent.cmd"),
       join(home, ".local", "bin", "agent.exe"),
+      join(home, ".local", "bin", "cursor-agent.exe"),
     ];
   }
   return [
+    join(home, ".local", "bin", "cursor-agent"),
     join(home, ".local", "bin", "agent"),
-    "/usr/local/bin/agent",
+    join(home, ".cursor", "bin", "cursor-agent"),
     join(home, ".cursor", "bin", "agent"),
+    "/usr/local/bin/cursor-agent",
+    "/usr/local/bin/agent",
   ];
 }
 
-export function getWhichCommand(): string {
-  return process.platform === "win32" ? "where agent 2>nul" : "which agent 2>/dev/null";
+export function getWhichAllCommand(): string {
+  return process.platform === "win32" ? "where agent 2>nul" : "which -a agent 2>/dev/null";
 }
 
 export type OutputFormat = "stream-json" | "json";

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,11 +1,11 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, realpathSync } from "fs";
 import { dirname, join } from "path";
 import { execSync } from "child_process";
 import type { PluginLogger } from "openclaw/plugin-sdk";
 import {
   getCursorMcpConfigPath,
   getCursorSearchPaths,
-  getWhichCommand,
+  getWhichAllCommand,
   MCP_SERVER_ID,
   OPENCLAW_CONFIG_PATH,
   type OutputFormat,
@@ -36,18 +36,54 @@ export type SetupResult = {
   warnings: string[];
 };
 
-export function detectCursorPath(overridePath?: string): string | null {
-  if (overridePath && existsSync(overridePath)) return overridePath;
+export function isCursorAgentBinary(cursorPath: string): boolean {
+  if (!cursorPath || !existsSync(cursorPath)) return false;
 
   try {
-    const which = execSync(getWhichCommand(), { encoding: "utf-8" }).trim();
-    const first = which.split("\n")[0]?.trim();
-    if (first && existsSync(first)) return first;
-  } catch { /* not on PATH */ }
-
-  for (const p of getCursorSearchPaths()) {
-    if (existsSync(p)) return p;
+    const resolved = realpathSync(cursorPath);
+    if (resolved.includes("cursor-agent")) return true;
+  } catch {
+    /* keep validating via --help */
   }
+
+  try {
+    const output = execSync(`"${cursorPath}" --help`, {
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return output.includes("Start the Cursor Agent")
+      || output.includes("--list-models")
+      || output.includes("stream-json");
+  } catch (e: any) {
+    const combined = `${e.stdout || ""}${e.stderr || ""}`;
+    return combined.includes("Start the Cursor Agent")
+      || combined.includes("--list-models")
+      || combined.includes("stream-json");
+  }
+}
+
+function listAgentCandidatesFromPath(): string[] {
+  try {
+    const output = execSync(getWhichAllCommand(), { encoding: "utf-8" }).trim();
+    if (!output) return [];
+    return [...new Set(output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean))];
+  } catch {
+    return [];
+  }
+}
+
+export function detectCursorPath(overridePath?: string): string | null {
+  if (overridePath && isCursorAgentBinary(overridePath)) return overridePath;
+
+  for (const candidate of getCursorSearchPaths()) {
+    if (isCursorAgentBinary(candidate)) return candidate;
+  }
+
+  for (const candidate of listAgentCandidatesFromPath()) {
+    if (isCursorAgentBinary(candidate)) return candidate;
+  }
+
   return null;
 }
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true
+  },
+  "include": [
+    "index.ts",
+    "src/**/*.ts",
+    "types/**/*.d.ts"
+  ]
+}

--- a/types/openclaw-plugin-sdk.d.ts
+++ b/types/openclaw-plugin-sdk.d.ts
@@ -10,8 +10,18 @@ declare module "openclaw/plugin-sdk" {
     pluginConfig: Record<string, unknown> | undefined;
     logger: PluginLogger;
     runtime: {
-      config: {
-        writeConfigFile(patch: Record<string, any>): Promise<void>;
+      config?: {
+        current(): Record<string, any>;
+        mutateConfigFile(params: {
+          afterWrite?: { mode: "auto" | "none" };
+          mutate: (draft: Record<string, any>, context?: unknown) => unknown;
+        }): Promise<unknown>;
+        replaceConfigFile(params: {
+          nextConfig: Record<string, any>;
+          afterWrite?: { mode: "auto" | "none" };
+        }): Promise<unknown>;
+        /** @deprecated Use mutateConfigFile or replaceConfigFile */
+        writeConfigFile?(patch: Record<string, any>): Promise<void>;
       };
     };
     resolvePath(rel: string): string;

--- a/types/openclaw-plugin-sdk.d.ts
+++ b/types/openclaw-plugin-sdk.d.ts
@@ -29,6 +29,7 @@ declare module "openclaw/plugin-sdk" {
       handler: (ctx: { program: any }) => void,
       opts?: { commands?: string[] },
     ): void;
+    registrationMode?: string;
   }
 
   export function emptyPluginConfigSchema(): Record<string, unknown>;

--- a/types/openclaw-plugin-sdk.d.ts
+++ b/types/openclaw-plugin-sdk.d.ts
@@ -29,6 +29,19 @@ declare module "openclaw/plugin-sdk" {
       handler: (ctx: { program: any }) => void,
       opts?: { commands?: string[] },
     ): void;
+    registerService?(service: {
+      id: string;
+      start: (ctx: {
+        config: Record<string, any>;
+        workspaceDir?: string;
+        logger: PluginLogger;
+      }) => void | Promise<void>;
+      stop?: (ctx: {
+        config: Record<string, any>;
+        workspaceDir?: string;
+        logger: PluginLogger;
+      }) => void | Promise<void>;
+    }): void;
     registrationMode?: string;
   }
 


### PR DESCRIPTION
## Summary
- Add a TypeScript build step that emits `dist/index.js` during `npm pack` / publish.
- Declare `openclaw.runtimeExtensions` so OpenClaw 2026.6+ can install the plugin from npm without the "requires compiled runtime output" error.
- Resolve plugin root paths correctly when the runtime entry is loaded from `dist/`.

## Problem
`openclaw plugins install openclaw-cursor-brain` fails on OpenClaw 2026.6.5 because the published tarball only contains `./index.ts` and no compiled JavaScript peer.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm pack --dry-run` includes `dist/index.js`
- [x] `openclaw plugins install ./openclaw-cursor-brain-1.5.4.tgz --force` passes plugin packaging validation and installs `dist/index.js`
- [ ] Maintainer publishes a new npm version after merge so `openclaw plugins install openclaw-cursor-brain` works from the registry


Made with [Cursor](https://cursor.com)